### PR TITLE
Another attempt at chat + email

### DIFF
--- a/src/main/java/edu/ucsb/cs156/gauchoride/controllers/ChatMessageController.java
+++ b/src/main/java/edu/ucsb/cs156/gauchoride/controllers/ChatMessageController.java
@@ -69,4 +69,15 @@ public class ChatMessageController extends ApiController {
         Page<ChatMessage> messages = chatMessageRepository.findAll(PageRequest.of(page, size, Sort.by("timestamp").descending()));
         return messages;
     }
+
+    @Operation(summary = "List all messages new way")
+    @PreAuthorize("hasRole('ROLE_ADMIN') || hasRole('ROLE_DRIVER')")
+    @GetMapping("/getNewThing")
+    public Page<ChatMessage> allMessagesNewWay(
+         @Parameter(name="page") @RequestParam int page,
+         @Parameter(name="size") @RequestParam int size
+    ) {
+        Page<ChatMessage> messages = chatMessageRepository.tryThing(PageRequest.of(page, size, Sort.by("timestamp").descending()));
+        return messages;
+    }
 }

--- a/src/main/java/edu/ucsb/cs156/gauchoride/controllers/ChatMessageController.java
+++ b/src/main/java/edu/ucsb/cs156/gauchoride/controllers/ChatMessageController.java
@@ -1,8 +1,7 @@
 package edu.ucsb.cs156.gauchoride.controllers;
 
 import edu.ucsb.cs156.gauchoride.entities.ChatMessage;
-import edu.ucsb.cs156.gauchoride.entities.User;
-import edu.ucsb.cs156.gauchoride.errors.EntityNotFoundException;
+import edu.ucsb.cs156.gauchoride.models.ChatMessageWithUserInfo;
 import edu.ucsb.cs156.gauchoride.repositories.ChatMessageRepository;
 
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -10,26 +9,15 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.autoconfigure.batch.BatchProperties.Job;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.security.core.authority.SimpleGrantedAuthority;
-import org.springframework.security.oauth2.jwt.NimbusReactiveJwtDecoder.SecretKeyReactiveJwtDecoderBuilder;
-import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.data.domain.Sort;
-
-import com.fasterxml.jackson.core.JsonProcessingException;
-
-import javax.validation.Valid;
-
 
 @Tag(name = "Chat Message")
 @RequestMapping("/api/chat")
@@ -59,25 +47,14 @@ public class ChatMessageController extends ApiController {
         return savedMessage;
     }
 
-    @Operation(summary = "List all messages")
+    @Operation(summary = "List all messages with user info")
     @PreAuthorize("hasRole('ROLE_ADMIN') || hasRole('ROLE_DRIVER')")
     @GetMapping("/get")
-    public Page<ChatMessage> allMessages(
+    public Page<ChatMessageWithUserInfo> allMessagesNewWay(
          @Parameter(name="page") @RequestParam int page,
          @Parameter(name="size") @RequestParam int size
     ) {
-        Page<ChatMessage> messages = chatMessageRepository.findAll(PageRequest.of(page, size, Sort.by("timestamp").descending()));
-        return messages;
-    }
-
-    @Operation(summary = "List all messages new way")
-    @PreAuthorize("hasRole('ROLE_ADMIN') || hasRole('ROLE_DRIVER')")
-    @GetMapping("/getNewThing")
-    public Page<ChatMessage> allMessagesNewWay(
-         @Parameter(name="page") @RequestParam int page,
-         @Parameter(name="size") @RequestParam int size
-    ) {
-        Page<ChatMessage> messages = chatMessageRepository.tryThing(PageRequest.of(page, size, Sort.by("timestamp").descending()));
+        Page<ChatMessageWithUserInfo> messages = chatMessageRepository.findAllWithUserInfo(PageRequest.of(page, size, Sort.by("timestamp").descending()));
         return messages;
     }
 }

--- a/src/main/java/edu/ucsb/cs156/gauchoride/entities/ChatMessage.java
+++ b/src/main/java/edu/ucsb/cs156/gauchoride/entities/ChatMessage.java
@@ -20,7 +20,7 @@ import lombok.Builder;
 @AllArgsConstructor
 @NoArgsConstructor
 @Builder
-@Entity(name = "chatMessage")
+@Entity(name = "chat_messages")
 public class ChatMessage {
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/edu/ucsb/cs156/gauchoride/entities/ChatMessage.java
+++ b/src/main/java/edu/ucsb/cs156/gauchoride/entities/ChatMessage.java
@@ -5,9 +5,6 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 
 import org.hibernate.annotations.CreationTimestamp;
-
-import io.swagger.v3.oas.annotations.media.Schema;
-
 import javax.persistence.GeneratedValue;
 
 import java.time.LocalDateTime;

--- a/src/main/java/edu/ucsb/cs156/gauchoride/models/ChatMessageWithUserInfo.java
+++ b/src/main/java/edu/ucsb/cs156/gauchoride/models/ChatMessageWithUserInfo.java
@@ -1,0 +1,17 @@
+package edu.ucsb.cs156.gauchoride.models;
+
+import edu.ucsb.cs156.gauchoride.entities.ChatMessage;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class ChatMessageWithUserInfo {
+  private ChatMessage chatMessage;
+  private String email;
+}

--- a/src/main/java/edu/ucsb/cs156/gauchoride/repositories/ChatMessageRepository.java
+++ b/src/main/java/edu/ucsb/cs156/gauchoride/repositories/ChatMessageRepository.java
@@ -5,10 +5,14 @@ import edu.ucsb.cs156.gauchoride.entities.ChatMessage;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface ChatMessageRepository extends CrudRepository<ChatMessage, Long> {
   public Page<ChatMessage> findAll(Pageable pageable);
+
+  @Query("SELECT m, u.email FROM chat_messages m, users u WHERE m.userId = u.id")
+  public Page<ChatMessage> tryThing(Pageable pageable);
 }

--- a/src/main/java/edu/ucsb/cs156/gauchoride/repositories/ChatMessageRepository.java
+++ b/src/main/java/edu/ucsb/cs156/gauchoride/repositories/ChatMessageRepository.java
@@ -1,7 +1,7 @@
 package edu.ucsb.cs156.gauchoride.repositories;
 
 import edu.ucsb.cs156.gauchoride.entities.ChatMessage;
-
+import edu.ucsb.cs156.gauchoride.models.ChatMessageWithUserInfo;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -13,6 +13,6 @@ import org.springframework.stereotype.Repository;
 public interface ChatMessageRepository extends CrudRepository<ChatMessage, Long> {
   public Page<ChatMessage> findAll(Pageable pageable);
 
-  @Query("SELECT m, u.email FROM chat_messages m, users u WHERE m.userId = u.id")
-  public Page<ChatMessage> tryThing(Pageable pageable);
+  @Query("SELECT new edu.ucsb.cs156.gauchoride.models.ChatMessageWithUserInfo(m, u.email) FROM chat_messages m, users u WHERE m.userId = u.id")
+  public Page<ChatMessageWithUserInfo> findAllWithUserInfo(Pageable pageable);
 }

--- a/src/main/java/edu/ucsb/cs156/gauchoride/repositories/RiderApplicationRepository.java
+++ b/src/main/java/edu/ucsb/cs156/gauchoride/repositories/RiderApplicationRepository.java
@@ -4,7 +4,6 @@ import edu.ucsb.cs156.gauchoride.entities.RiderApplication;
 
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.stereotype.Repository;
-import java.util.Optional;
 
 @Repository
 public interface RiderApplicationRepository extends CrudRepository<RiderApplication, Long> {

--- a/src/test/java/edu/ucsb/cs156/gauchoride/controllers/ChatMessageControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/gauchoride/controllers/ChatMessageControllerTests.java
@@ -2,21 +2,18 @@ package edu.ucsb.cs156.gauchoride.controllers;
 
 import edu.ucsb.cs156.gauchoride.ControllerTestCase;
 import edu.ucsb.cs156.gauchoride.entities.ChatMessage;
-import edu.ucsb.cs156.gauchoride.entities.Ride;
+import edu.ucsb.cs156.gauchoride.models.ChatMessageWithUserInfo;
 import edu.ucsb.cs156.gauchoride.repositories.ChatMessageRepository;
 import edu.ucsb.cs156.gauchoride.repositories.UserRepository;
 import edu.ucsb.cs156.gauchoride.testconfig.TestConfig;
 
-import org.aspectj.bridge.Message;
 import org.junit.jupiter.api.Test;
-import org.springframework.boot.autoconfigure.batch.BatchProperties.Job;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MvcResult;
-import org.springframework.test.web.servlet.result.FlashAttributeResultMatchers;
 import static org.mockito.Mockito.atLeastOnce;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -34,20 +31,19 @@ import org.springframework.data.domain.PageRequest;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Map;
-import java.util.Optional;
+
 
 @WebMvcTest(controllers = ChatMessageController.class)
 @Import(TestConfig.class)
-public class ChatMessageControllerTests extends ControllerTestCase{
-  
-    @MockBean
-    UserRepository userRepository;
+public class ChatMessageControllerTests extends ControllerTestCase {
 
-    @MockBean
-    ChatMessageRepository chatMessageRepository;
+        @MockBean
+        UserRepository userRepository;
 
-    @WithMockUser(roles = { "ADMIN" })
+        @MockBean
+        ChatMessageRepository chatMessageRepository;
+
+        @WithMockUser(roles = { "ADMIN" })
         @Test
         public void admin_can_get_messages() throws Exception {
 
@@ -56,20 +52,23 @@ public class ChatMessageControllerTests extends ControllerTestCase{
                 PageRequest pageRequest = PageRequest.of(0, 5);
 
                 ChatMessage message1 = ChatMessage.builder()
-                    .userId(1)
-                    .payload("message2")
-                    .build();
+                                .userId(1)
+                                .payload("message2")
+                                .build();
                 ChatMessage message2 = ChatMessage.builder()
-                    .userId(1)
-                    .payload("message2")
-                    .build();
+                                .userId(1)
+                                .payload("message2")
+                                .build();
 
-                ArrayList<ChatMessage> expectedMessages = new ArrayList<>();
-                expectedMessages.addAll(Arrays.asList(message1, message2));
+                ArrayList<ChatMessageWithUserInfo> expectedMessages = new ArrayList<>();
+                expectedMessages.addAll(Arrays.asList(
+                                new ChatMessageWithUserInfo(message1, "cgaucho@ucsb.edu"),
+                                new ChatMessageWithUserInfo(message2, "cgaucho@ucsb.edu")));
 
-                Page<ChatMessage> expectedMessagePage = new PageImpl<>(expectedMessages, pageRequest, expectedMessages.size());
+                Page<ChatMessageWithUserInfo> expectedMessagePage = new PageImpl<>(expectedMessages, pageRequest,
+                                expectedMessages.size());
 
-                when(chatMessageRepository.findAll(any())).thenReturn(expectedMessagePage);
+                when(chatMessageRepository.findAllWithUserInfo(any())).thenReturn(expectedMessagePage);
 
                 // act
                 MvcResult response = mockMvc.perform(get("/api/chat/get?page=0&size=10"))
@@ -77,13 +76,12 @@ public class ChatMessageControllerTests extends ControllerTestCase{
 
                 // assert
 
-                verify(chatMessageRepository, atLeastOnce()).findAll(any());
+                verify(chatMessageRepository, atLeastOnce()).findAllWithUserInfo(any());
 
                 String expectedJson = mapper.writeValueAsString(expectedMessagePage);
                 String responseString = response.getResponse().getContentAsString();
                 assertEquals(expectedJson, responseString);
         }
-
 
         @WithMockUser(roles = { "DRIVER" })
         @Test
@@ -94,20 +92,23 @@ public class ChatMessageControllerTests extends ControllerTestCase{
                 PageRequest pageRequest = PageRequest.of(0, 5);
 
                 ChatMessage message1 = ChatMessage.builder()
-                    .userId(1)
-                    .payload("message2")
-                    .build();
+                                .userId(1)
+                                .payload("message2")
+                                .build();
                 ChatMessage message2 = ChatMessage.builder()
-                    .userId(1)
-                    .payload("message2")
-                    .build();
+                                .userId(1)
+                                .payload("message2")
+                                .build();
 
-                ArrayList<ChatMessage> expectedMessages = new ArrayList<>();
-                expectedMessages.addAll(Arrays.asList(message1, message2));
+                ArrayList<ChatMessageWithUserInfo> expectedMessages = new ArrayList<>();
+                expectedMessages.addAll(Arrays.asList(
+                                new ChatMessageWithUserInfo(message1, "cgaucho@ucsb.edu"),
+                                new ChatMessageWithUserInfo(message2, "cgaucho@ucsb.edu")));
 
-                Page<ChatMessage> expectedMessagePage = new PageImpl<>(expectedMessages, pageRequest, expectedMessages.size());
+                Page<ChatMessageWithUserInfo> expectedMessagePage = new PageImpl<>(expectedMessages, pageRequest,
+                                expectedMessages.size());
 
-                when(chatMessageRepository.findAll(any())).thenReturn(expectedMessagePage);
+                when(chatMessageRepository.findAllWithUserInfo(any())).thenReturn(expectedMessagePage);
 
                 // act
                 MvcResult response = mockMvc.perform(get("/api/chat/get?page=0&size=10"))
@@ -115,13 +116,12 @@ public class ChatMessageControllerTests extends ControllerTestCase{
 
                 // assert
 
-                verify(chatMessageRepository, atLeastOnce()).findAll(any());
+                verify(chatMessageRepository, atLeastOnce()).findAllWithUserInfo(any());
 
                 String expectedJson = mapper.writeValueAsString(expectedMessagePage);
                 String responseString = response.getResponse().getContentAsString();
                 assertEquals(expectedJson, responseString);
         }
-
 
         @WithMockUser(roles = { "ADMIN" })
         @Test
@@ -131,9 +131,9 @@ public class ChatMessageControllerTests extends ControllerTestCase{
                 long userId = currentUserService.getCurrentUser().getUser().getId();
 
                 ChatMessage message1 = ChatMessage.builder()
-                        .userId(userId)
-                        .payload("message1")
-                        .build();
+                                .userId(userId)
+                                .payload("message1")
+                                .build();
 
                 when(chatMessageRepository.save(eq(message1))).thenReturn(message1);
 
@@ -151,7 +151,6 @@ public class ChatMessageControllerTests extends ControllerTestCase{
                 String responseString = response.getResponse().getContentAsString();
                 assertEquals(expectedJson, responseString);
         }
-
 
         @WithMockUser(roles = { "DRIVER" })
         @Test
@@ -161,9 +160,9 @@ public class ChatMessageControllerTests extends ControllerTestCase{
                 long userId = currentUserService.getCurrentUser().getUser().getId();
 
                 ChatMessage message1 = ChatMessage.builder()
-                        .userId(userId)
-                        .payload("message1")
-                        .build();
+                                .userId(userId)
+                                .payload("message1")
+                                .build();
 
                 when(chatMessageRepository.save(eq(message1))).thenReturn(message1);
 
@@ -179,13 +178,8 @@ public class ChatMessageControllerTests extends ControllerTestCase{
                 verify(chatMessageRepository, times(1)).save(message1);
                 String expectedJson = "{\"id\":0,\"userId\":1,\"payload\":\"message1\",\"timestamp\":null,\"dm\":false,\"toUserId\":null}";
                 String responseString = response.getResponse().getContentAsString();
-                
+
                 assertEquals(expectedJson, responseString);
         }
-
-
-    
-
-
 
 }

--- a/src/test/java/edu/ucsb/cs156/gauchoride/controllers/UsersControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/gauchoride/controllers/UsersControllerTests.java
@@ -11,7 +11,6 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MvcResult;
-import org.springframework.test.web.servlet.result.FlashAttributeResultMatchers;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;


### PR DESCRIPTION
In this PR, @Mohamed-Elfouly and @pconrad collaborated on an update to the ChatMessagesController so that email address of the sender is conveyed through the backend `GET` endpoint for chat messages.

Before, only the user id of the sender was available, which is not all that interesting for end users.  They would prefer to know who the message is from by, for example, the email address.

In future PRs, additional fields such as fullName, familyName, givenName could also be added.  It is worth noting that email is the only field that is both meaningful to humans, and uniquely identifies a sender (if we used full name, for example, there might be two 'Chris Smith`s in the same class.)